### PR TITLE
Add server response to Error message

### DIFF
--- a/src/smtp-connection.js
+++ b/src/smtp-connection.js
@@ -394,7 +394,7 @@ SMTPConnection.prototype._formatError = function(message, type, response) {
 
     if (response) {
         err.response = response;
-        message += (',' + response);
+        err.message += (':' + response);
     }
 
     var responseCode = typeof response === 'string' && Number((response.match(/^\d+/) || [])[0]) || false;

--- a/src/smtp-connection.js
+++ b/src/smtp-connection.js
@@ -394,6 +394,7 @@ SMTPConnection.prototype._formatError = function(message, type, response) {
 
     if (response) {
         err.response = response;
+        message += (',' + response);
     }
 
     var responseCode = typeof response === 'string' && Number((response.match(/^\d+/) || [])[0]) || false;


### PR DESCRIPTION
I think the error message should append smtp server response.
When I got 'Error: Mail command failed', I don't know how to fix it until I check the stack and find out the response msg : "'501 mail from address must be same as authorization user"